### PR TITLE
Multiple connections to RabbitMQ

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension AnyEvent::RabbitMQ
 
+        - Allow multiple clients to have independent connections
+          to RabbitMQ, as long as they all use the same spec file.
+
 1.05    Tue Jul 22 16:55:55 2011
         - Fixed a compiling error.
 

--- a/lib/AnyEvent/RabbitMQ.pm
+++ b/lib/AnyEvent/RabbitMQ.pm
@@ -4,7 +4,7 @@ use strict;
 use warnings;
 
 use Data::Dumper;
-use Carp qw(confess);
+use Carp qw(confess croak);
 use List::MoreUtils qw(none);
 use Devel::GlobalDestruction;
 use namespace::clean;
@@ -54,12 +54,17 @@ sub login_user {
     return $self->{_login_user};
 }
 
+my $_loaded_spec;
 sub load_xml_spec {
     my $self = shift;
     my ($spec) = @_;
-    Net::AMQP::Protocol->load_xml_spec(
-        $spec || $DEFAULT_AMQP_SPEC
-    ); # die when fail in this line.
+    $spec ||= $DEFAULT_AMQP_SPEC;
+    if ($_loaded_spec && $_loaded_spec ne $spec) {
+        croak("Tried to load AMQP spec $spec, but have already loaded $_loaded_spec, not possible");
+    }
+    elsif (!$_loaded_spec) {
+        Net::AMQP::Protocol->load_xml_spec($_loaded_spec = $spec);
+    }
     return $self;
 }
 


### PR DESCRIPTION
Hi.

I've just committed a change to allow you to have multiple connections to AMQP.

I need this as I want to run generic job workers which may connect to AMQP to initially get a job, then disconnect, and then run code which wants to start it's own RabbitMQ connection to log statuses as it runs.
